### PR TITLE
Shahram/signature

### DIFF
--- a/apps/remix/app/components/general/document-signing/document-signing-signature-field.tsx
+++ b/apps/remix/app/components/general/document-signing/document-signing-signature-field.tsx
@@ -6,6 +6,7 @@ import { Trans } from '@lingui/react/macro';
 import { Loader } from 'lucide-react';
 import { useRevalidator } from 'react-router';
 
+import { useDraggableSignaturePosition } from '@documenso/lib/client-only/hooks/use-draggable-signature-position';
 import { DO_NOT_INVALIDATE_QUERY_ON_MUTATION } from '@documenso/lib/constants/trpc';
 import { AppError, AppErrorCode } from '@documenso/lib/errors/app-error';
 import type { TRecipientActionAuth } from '@documenso/lib/types/document-auth';
@@ -70,6 +71,9 @@ export const DocumentSigningSignatureField = ({
   } = trpc.field.removeSignedFieldWithToken.useMutation(DO_NOT_INVALIDATE_QUERY_ON_MUTATION);
 
   const { signature } = field;
+  const canDrag = !field.inserted;
+  const drag = useDraggableSignaturePosition({ field, enabled: canDrag });
+  const pixels = drag.toPixels();
 
   const isLoading = isSignFieldWithTokenLoading || isRemoveSignedFieldWithTokenLoading;
 
@@ -140,6 +144,8 @@ export const DocumentSigningSignatureField = ({
         value,
         isBase64: !isTypedSignature,
         authOptions,
+        signaturePositionX: drag.posPercent.x,
+        signaturePositionY: drag.posPercent.y,
       };
 
       if (onSignField) {
@@ -234,6 +240,14 @@ export const DocumentSigningSignatureField = ({
       onSign={onSign}
       onRemove={onRemove}
       type="Signature"
+      overrideCoords={
+        pixels
+          ? { x: pixels.x, y: pixels.y, width: pixels.width, height: pixels.height }
+          : undefined
+      }
+      onSignaturePointerDown={drag.onPointerDown}
+      onSignaturePointerMove={drag.onPointerMove}
+      onSignaturePointerUp={drag.onPointerUp}
     >
       {isLoading && (
         <div className="bg-background absolute inset-0 flex items-center justify-center rounded-md">
@@ -242,7 +256,7 @@ export const DocumentSigningSignatureField = ({
       )}
 
       {state === 'empty' && (
-        <p className="group-hover:text-primary font-signature text-muted-foreground group-hover:text-recipient-green text-[clamp(0.575rem,25cqw,1.2rem)] text-xl duration-200">
+        <p className="group-hover:text-primary font-signature text-muted-foreground hover:text-background text-[clamp(0.575rem,25cqw,1.2rem)] text-xl duration-200">
           <Trans>Signature</Trans>
         </p>
       )}

--- a/packages/lib/client-only/hooks/use-draggable-signature-position.ts
+++ b/packages/lib/client-only/hooks/use-draggable-signature-position.ts
@@ -1,0 +1,148 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+
+import type { FieldWithSignature } from '@documenso/prisma/types/field-with-signature';
+
+import { PDF_VIEWER_PAGE_SELECTOR } from '../../constants/pdf-viewer';
+import { getBoundingClientRect } from '../get-bounding-client-rect';
+
+type PercentCoords = { x: number; y: number };
+type PixelCoords = { x: number; y: number; width: number; height: number };
+
+export type UseDraggableSignaturePositionOptions = {
+  field: FieldWithSignature;
+  enabled: boolean;
+};
+
+export type UseDraggableSignaturePosition = {
+  posPercent: PercentCoords;
+  toPixels: () => PixelCoords | null;
+  onPointerDown: (e: React.PointerEvent) => void;
+  onPointerMove: (e: React.PointerEvent) => void;
+  onPointerUp: (e: React.PointerEvent) => boolean;
+};
+
+function clamp(value: number, min: number, max: number): number {
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}
+
+export function useDraggableSignaturePosition(
+  options: UseDraggableSignaturePositionOptions,
+): UseDraggableSignaturePosition {
+  const { field, enabled } = options;
+
+  const widthPercent = Number(field.width) > 0 ? Number(field.width) : 0;
+  const heightPercent = Number(field.height) > 0 ? Number(field.height) : 0;
+
+  const initialPercent = useMemo<PercentCoords>(() => {
+    const sigX = field.signature?.signaturePositionX;
+    const sigY = field.signature?.signaturePositionY;
+
+    if (sigX !== undefined && sigX !== null && sigY !== undefined && sigY !== null) {
+      return { x: Number(sigX), y: Number(sigY) };
+    }
+
+    return { x: Number(field.positionX), y: Number(field.positionY) };
+  }, [
+    field.positionX,
+    field.positionY,
+    field.signature?.signaturePositionX,
+    field.signature?.signaturePositionY,
+  ]);
+
+  const [posPercent, setPosPercent] = useState<PercentCoords>(initialPercent);
+  const isPointerDownRef = useRef(false);
+  const didDragRef = useRef(false);
+  const startClientRef = useRef<{ x: number; y: number } | null>(null);
+
+  const getPageEl = useCallback((): HTMLElement | null => {
+    return document.querySelector<HTMLElement>(
+      `${PDF_VIEWER_PAGE_SELECTOR}[data-page-number="${field.page}"]`,
+    );
+  }, [field.page]);
+
+  const toPixels = useCallback((): PixelCoords | null => {
+    const $page = getPageEl();
+    if (!$page) return null;
+
+    const { top, left, height, width } = getBoundingClientRect($page);
+
+    const xPx = (posPercent.x / 100) * width + left;
+    const yPx = (posPercent.y / 100) * height + top;
+    const wPx = (widthPercent / 100) * width;
+    const hPx = (heightPercent / 100) * height;
+
+    return { x: xPx, y: yPx, width: wPx, height: hPx };
+  }, [getPageEl, heightPercent, posPercent.x, posPercent.y, widthPercent]);
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      if (!enabled) return;
+      isPointerDownRef.current = true;
+      didDragRef.current = false;
+      startClientRef.current = { x: e.clientX, y: e.clientY };
+    },
+    [enabled],
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!enabled || !isPointerDownRef.current) return;
+
+      const $page = getPageEl();
+      if (!$page) return;
+
+      const { top, left, width, height } = $page.getBoundingClientRect();
+
+      let xPercent = ((e.clientX - left) / width) * 100;
+      let yPercent = ((e.clientY - top) / height) * 100;
+
+      xPercent -= widthPercent / 2;
+      yPercent -= heightPercent / 2;
+
+      xPercent = clamp(xPercent, 0, Math.max(0, 100 - widthPercent));
+      yPercent = clamp(yPercent, 0, Math.max(0, 100 - heightPercent));
+
+      const start = startClientRef.current;
+      if (start) {
+        const dx = Math.abs(e.clientX - start.x);
+        const dy = Math.abs(e.clientY - start.y);
+        if (dx > 3 || dy > 3) {
+          didDragRef.current = true;
+        }
+      }
+
+      setPosPercent({ x: xPercent, y: yPercent });
+
+      const el = document.getElementById(`field-${field.id}`);
+      if (el?.parentElement) {
+        el.parentElement.setAttribute('data-validate', 'true');
+        requestAnimationFrame(() => {
+          el.parentElement?.setAttribute('data-validate', 'false');
+        });
+      }
+    },
+    [enabled, getPageEl, heightPercent, widthPercent, field.id],
+  );
+
+  const onPointerUp = useCallback(
+    (_e: React.PointerEvent) => {
+      if (!enabled) return false;
+      const didDrag = didDragRef.current;
+      isPointerDownRef.current = false;
+      didDragRef.current = false;
+      startClientRef.current = null;
+      return didDrag;
+    },
+    [enabled],
+  );
+
+  return {
+    posPercent,
+    toPixels,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+  };
+}

--- a/packages/lib/server-only/pdf/insert-field-in-pdf.ts
+++ b/packages/lib/server-only/pdf/insert-field-in-pdf.ts
@@ -88,8 +88,16 @@ export const insertFieldInPDF = async (pdf: PDFDocument, field: FieldWithSignatu
   const fieldWidth = pageWidth * (Number(field.width) / 100);
   const fieldHeight = pageHeight * (Number(field.height) / 100);
 
-  const fieldX = pageWidth * (Number(field.positionX) / 100);
-  const fieldY = pageHeight * (Number(field.positionY) / 100);
+  // Use signature-level coordinates for signature fields; otherwise use Field coords
+  const useX = isSignatureField
+    ? Number(field.signature?.signaturePositionX)
+    : Number(field.positionX);
+  const useY = isSignatureField
+    ? Number(field.signature?.signaturePositionY)
+    : Number(field.positionY);
+
+  const fieldX = pageWidth * (useX / 100);
+  const fieldY = pageHeight * (useY / 100);
 
   // Draw debug box if debug mode is enabled
   if (isDebugMode) {

--- a/packages/lib/server-only/pdf/legacy-insert-field-in-pdf.ts
+++ b/packages/lib/server-only/pdf/legacy-insert-field-in-pdf.ts
@@ -81,8 +81,16 @@ export const legacy_insertFieldInPDF = async (pdf: PDFDocument, field: FieldWith
   const fieldWidth = pageWidth * (Number(field.width) / 100);
   const fieldHeight = pageHeight * (Number(field.height) / 100);
 
-  const fieldX = pageWidth * (Number(field.positionX) / 100);
-  const fieldY = pageHeight * (Number(field.positionY) / 100);
+  // Use signature-level coordinates for signature fields; otherwise use Field coords
+  const useX = isSignatureField
+    ? Number(field.signature?.signaturePositionX)
+    : Number(field.positionX);
+  const useY = isSignatureField
+    ? Number(field.signature?.signaturePositionY)
+    : Number(field.positionY);
+
+  const fieldX = pageWidth * (useX / 100);
+  const fieldY = pageHeight * (useY / 100);
 
   // Draw debug box if debug mode is enabled
   if (isDebugMode) {

--- a/packages/lib/server-only/template/create-document-from-direct-template.ts
+++ b/packages/lib/server-only/template/create-document-from-direct-template.ts
@@ -441,6 +441,8 @@ export const createDocumentFromDirectTemplate = async ({
                   recipientId: createdDirectRecipient.id,
                   signatureImageAsBase64: signature.signatureImageAsBase64,
                   typedSignature: signature.typedSignature,
+                  signaturePositionX: templateField.positionX,
+                  signaturePositionY: templateField.positionY,
                 },
               },
             },

--- a/packages/prisma/migrations/20250930221646_add_signature_cords/migration.sql
+++ b/packages/prisma/migrations/20250930221646_add_signature_cords/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Signature" ADD COLUMN     "signaturePositionX" DECIMAL(65,30),
+ADD COLUMN     "signaturePositionY" DECIMAL(65,30);

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -549,6 +549,8 @@ model Signature {
   fieldId                Int      @unique
   signatureImageAsBase64 String?
   typedSignature         String?
+  signaturePositionX     Decimal?
+  signaturePositionY     Decimal?
 
   recipient Recipient @relation(fields: [recipientId], references: [id], onDelete: Cascade)
   field     Field     @relation(fields: [fieldId], references: [id], onDelete: Cascade)

--- a/packages/trpc/server/field-router/router.ts
+++ b/packages/trpc/server/field-router/router.ts
@@ -446,7 +446,15 @@ export const fieldRouter = router({
   signFieldWithToken: procedure
     .input(ZSignFieldWithTokenMutationSchema)
     .mutation(async ({ input, ctx }) => {
-      const { token, fieldId, value, isBase64, authOptions } = input;
+      const {
+        token,
+        fieldId,
+        value,
+        isBase64,
+        authOptions,
+        signaturePositionX,
+        signaturePositionY,
+      } = input;
 
       return await signFieldWithToken({
         token,
@@ -456,6 +464,8 @@ export const fieldRouter = router({
         userId: ctx.user?.id,
         authOptions,
         requestMetadata: ctx.metadata.requestMetadata,
+        signaturePositionX,
+        signaturePositionY,
       });
     }),
 

--- a/packages/trpc/server/field-router/schema.ts
+++ b/packages/trpc/server/field-router/schema.ts
@@ -156,6 +156,8 @@ export const ZSignFieldWithTokenMutationSchema = z.object({
   value: z.string().trim().optional(),
   isBase64: z.boolean().optional(),
   authOptions: ZRecipientActionAuthSchema.optional(),
+  signaturePositionX: z.number().optional(),
+  signaturePositionY: z.number().optional(),
 });
 
 export type TSignFieldWithTokenMutationSchema = z.infer<typeof ZSignFieldWithTokenMutationSchema>;

--- a/packages/ui/components/field/field-tooltip.tsx
+++ b/packages/ui/components/field/field-tooltip.tsx
@@ -1,9 +1,12 @@
+import { useEffect, useState } from 'react';
+
 import type { Field } from '@prisma/client';
 import { TooltipArrow } from '@radix-ui/react-tooltip';
 import type { VariantProps } from 'class-variance-authority';
 import { cva } from 'class-variance-authority';
 import { createPortal } from 'react-dom';
 
+import { getBoundingClientRect } from '@documenso/lib/client-only/get-bounding-client-rect';
 import { useFieldPageCoords } from '@documenso/lib/client-only/hooks/use-field-page-coords';
 
 import { cn } from '../..//lib/utils';
@@ -36,7 +39,49 @@ interface FieldToolTipProps extends VariantProps<typeof tooltipVariants> {
  * Renders a tooltip for a given field.
  */
 export function FieldToolTip({ children, color, className = '', field }: FieldToolTipProps) {
-  const coords = useFieldPageCoords(field);
+  const fallback = useFieldPageCoords(field);
+  const [coords, setCoords] = useState(fallback);
+
+  useEffect(() => {
+    const maybeEl = document.getElementById(`field-${field.id}`);
+    const el: HTMLElement | null = maybeEl instanceof HTMLElement ? maybeEl : null;
+    if (!el) {
+      setCoords(fallback);
+      return;
+    }
+
+    const update = () => {
+      const targetEl = el.parentElement instanceof HTMLElement ? el.parentElement : el;
+      const { top, left, width, height } = getBoundingClientRect(targetEl);
+      setCoords({ x: left, y: top, width, height });
+    };
+
+    update();
+
+    const ro = new ResizeObserver(() => update());
+    ro.observe(el);
+    if (el.parentElement instanceof HTMLElement) ro.observe(el.parentElement);
+
+    const mo = new MutationObserver(() => update());
+    mo.observe(el, { attributes: true, attributeFilter: ['style', 'class', 'data-validate'] });
+    if (el.parentElement)
+      mo.observe(el.parentElement, {
+        attributes: true,
+        attributeFilter: ['style', 'class', 'data-validate'],
+      });
+
+    const onResize = () => update();
+    const onScroll = () => update();
+    window.addEventListener('resize', onResize);
+    window.addEventListener('scroll', onScroll, true);
+
+    return () => {
+      ro.disconnect();
+      mo.disconnect();
+      window.removeEventListener('resize', onResize);
+      window.removeEventListener('scroll', onScroll, true);
+    };
+  }, [field.id]);
 
   return createPortal(
     <div
@@ -49,7 +94,11 @@ export function FieldToolTip({ children, color, className = '', field }: FieldTo
       }}
     >
       <TooltipProvider>
-        <Tooltip delayDuration={0} open={!field.inserted || !field.fieldMeta}>
+        <Tooltip
+          key={`${field.id}-${coords.x}-${coords.y}-${coords.width}-${coords.height}`}
+          delayDuration={0}
+          open={!field.inserted || !field.fieldMeta}
+        >
           <TooltipTrigger className="absolute inset-0 w-full"></TooltipTrigger>
 
           <TooltipContent className={tooltipVariants({ color, className })} sideOffset={2}>

--- a/packages/ui/components/field/field.tsx
+++ b/packages/ui/components/field/field.tsx
@@ -13,23 +13,25 @@ export type FieldContainerPortalProps = {
   field: Field;
   className?: string;
   children: React.ReactNode;
+  overrideCoords?: { x: number; y: number; width?: number; height?: number };
 };
 
 export function FieldContainerPortal({
   field,
   children,
   className = '',
+  overrideCoords,
 }: FieldContainerPortalProps) {
   const coords = useFieldPageCoords(field);
 
   const isCheckboxOrRadioField = field.type === 'CHECKBOX' || field.type === 'RADIO';
 
-  const style = {
-    top: `${coords.y}px`,
-    left: `${coords.x}px`,
+  const style: React.CSSProperties = {
+    top: `${overrideCoords?.y ?? coords.y}px`,
+    left: `${overrideCoords?.x ?? coords.x}px`,
     ...(!isCheckboxOrRadioField && {
-      height: `${coords.height}px`,
-      width: `${coords.width}px`,
+      height: `${overrideCoords?.height ?? coords.height}px`,
+      width: `${overrideCoords?.width ?? coords.width}px`,
     }),
   };
 
@@ -46,9 +48,16 @@ export type FieldRootContainerProps = {
   color?: RecipientColorStyles;
   children: React.ReactNode;
   className?: string;
+  overrideCoords?: { x: number; y: number; width?: number; height?: number };
 };
 
-export function FieldRootContainer({ field, children, color, className }: FieldRootContainerProps) {
+export function FieldRootContainer({
+  field,
+  children,
+  color,
+  className,
+  overrideCoords,
+}: FieldRootContainerProps) {
   const [isValidating, setIsValidating] = useState(false);
   const ref = React.useRef<HTMLDivElement>(null);
 
@@ -73,7 +82,7 @@ export function FieldRootContainer({ field, children, color, className }: FieldR
   }, []);
 
   return (
-    <FieldContainerPortal field={field}>
+    <FieldContainerPortal field={field} overrideCoords={overrideCoords}>
       <div
         id={`field-${field.id}`}
         ref={ref}


### PR DESCRIPTION
---
name: Add Signature DnD for signee
---

## Description

The compatitors have a feature where the signee can change the position of the field being punched into the document. We specifically wanted to allow the signee to change the position of the Signature, where other fields keep their behavior of being fixed.

This PR adds the DnD (drag-and-drop) feature for Signature field. The signee can now change the position of the signature field.

## Changes Made

- add `signaturePositionX` and `signaturePositionY` fields in `Signature` model in `schema.prisma`
- update `signFieldWithToken` `trpc` api to accept above position values for `Signature` field.
- when sealing the document, newly added fields are used (for signature only).

## Checklist

- [x] I have tested these changes locally and they work as expected.
- [ ] I have updated the documentation to reflect these changes, if applicable.
- [x] I have followed the project's coding style guidelines.

## Additional Notes

The `positionX` and `positionY` in the `Field` model isused to set the default position of the signature only. When sealing the document, `signaturePositionX` and `signaturePositionY` should be used.
This apply only in case of `Field.Signature`.
